### PR TITLE
Make health view the default view.

### DIFF
--- a/web/js/nms.js
+++ b/web/js/nms.js
@@ -414,7 +414,7 @@ function detectHandler() {
 	var views = document.location.hash.slice(1);
 	var interval = nms.interval;
 	if (views == undefined || views == "")
-		views = "ping";
+		views = "health";
 	views = views.split(",");
 
 	if (views.length > 1) {


### PR DESCRIPTION
I think it makes sense to make the health view the default view. It's the top view in the menu, it's keybound to `1` and it gives you a quick overview.