### PR TITLE
Set Client ports description to "None configured" if no configured client ports

### DIFF
--- a/web/js/nms-map-handlers.js
+++ b/web/js/nms-map-handlers.js
@@ -184,7 +184,7 @@ function uplinkInfo(sw)
 		var tu = parseInt(nmsData.switchstate.switches[sw].clients.live);
 		var tt = parseInt(nmsData.switchstate.switches[sw].clients.total);
 		ret.data[1] = {};
-		ret.data[1].value = (tu) + " / " + (tt);
+		ret.data[1].value = (tu && tt) ? (tu) + " / " + (tt) : "None configured";
 		ret.data[1].description = "Client ports (live/total)";
 	}
 	if (testTree(nmsData,['switchstate','switches',sw,'totals','live'])) {


### PR DESCRIPTION
This fixes a bug where "Client ports" value could be "0 / NaN" if no client ports were configured.

Client ports can be reported as `0 / NaN`. The API might respond with information about number of live clients without information about total clients, if the number is 0. (Source: https://github.com/tech-server/gondul/blob/05e09f3b63269a48d1beb0dc9900b180101cec7f/web/api/public/switch-state#L28-L29 -- `total` is never initialized (but `live` is) and will therefore not exist in the json source if no client ports were configured for the switch.)

Before:
![image](https://user-images.githubusercontent.com/5422571/38125460-dfe3984c-33e9-11e8-97ba-53f0bae7ac3b.png)

After:
![image](https://user-images.githubusercontent.com/5422571/38126266-b9652b4e-33ef-11e8-8f15-ddcffa68c121.png)

Linge approves with love.